### PR TITLE
Replace Smartmatch with grep

### DIFF
--- a/source/dinaip.pl
+++ b/source/dinaip.pl
@@ -352,7 +352,7 @@ sub eliminarZona{
 		}
 	}
 	else{
-		unless ($zonas  ~~ @dominios_vigilados){
+		unless (grep { $_ eq $zonas } @dominios_vigilados){
 			print "Error. El dominio $zonas no esta siendo vigilado\n";
 			exit(1);
 		}


### PR DESCRIPTION
En Perl 5.18 (Mayo de 2013) se marcó como deprecado el  Smartmatch. 
Esta funcionalidad ha sido finalmente eliminada de Perl en 5.38 (Junio de 2023), por lo que DinaIp falla al hacer uno de ella.

Se reemplaza por grep.